### PR TITLE
修复字符串搜索算法中 pattern 为空或越界导致的崩溃

### DIFF
--- a/src/boyer_moore.mbt
+++ b/src/boyer_moore.mbt
@@ -2,6 +2,9 @@
 fn boyer_moore(text : String, pattern : String) -> Int {
   let n = text.length()
   let m = pattern.length()
+  if m == 0 || n == 0 || m > n {
+    return -1
+  }
   let bad_char = compute_bad_char_table(pattern)
   let good_suffix = compute_good_suffix_table(pattern)
   let mut i = 0
@@ -32,4 +35,11 @@ test "boyer_moore/basic" {
 test "boyer_moore/pattern_not_found" {
   inspect!(boyer_moore("hello world", "moon"), content="-1")
   inspect!(boyer_moore("AABAACAADAABAAABAA", "ZZZ"), content="-1")
+}
+
+///
+test "boyer_moore/empty" {
+  inspect!(boyer_moore("", ""), content="-1")
+  inspect!(boyer_moore("hello world", ""), content="-1")
+  inspect!(boyer_moore("", "world"), content="-1")
 }

--- a/src/kmp.mbt
+++ b/src/kmp.mbt
@@ -2,6 +2,9 @@
 fn kmp(text : String, pattern : String) -> Int {
   let n = text.length()
   let m = pattern.length()
+  if m == 0 || n == 0 || m > n {
+    return -1
+  }
   let lps = compute_lps(pattern)
   let mut i = 0
   let mut j = 0
@@ -34,4 +37,11 @@ test "boyer_moore/basic" {
 test "boyer_moore/pattern_not_found" {
   inspect!(kmp("hello world", "moon"), content="-1")
   inspect!(kmp("AABAACAADAABAAABAA", "ZZZ"), content="-1")
+}
+
+///
+test "kmp/empty" {
+  inspect!(kmp("", ""), content="-1")
+  inspect!(kmp("hello world", ""), content="-1")
+  inspect!(kmp("", "world"), content="-1")
 }

--- a/src/rabin_karp.mbt
+++ b/src/rabin_karp.mbt
@@ -20,7 +20,7 @@ fn StringHash::new(
   h[0] = 1
   for i = 1; i <= n; i = i + 1 {
     p[i] = p[i - 1] * base % mod
-    h[i] = (h[i - 1] * base + (s[i - 1] - 'a' + 1).to_int64()) % mod
+    h[i] = (h[i - 1] * base + ((s[i - 1].to_int() - 'a'.to_int() + 1).to_int64())) % mod
   }
   StringHash::{ n, mod, base, hash: h, p } // 直接传入p数组
 }
@@ -40,6 +40,9 @@ fn StringHash::get_hash(self : StringHash, left : Int, right : Int) -> Int64 {
 fn rabin_karp(text : String, pattern : String) -> Int {
   let n = text.length()
   let m = pattern.length()
+  if m == 0 || n == 0 || m > n {
+    return -1
+  }  
   let text_hash = StringHash::new(text)
   let pattern_hash = StringHash::new(pattern)
   let pattern_hash_value = pattern_hash.get_hash(0, m - 1)
@@ -72,4 +75,11 @@ test "boyer_moore/basic" {
 test "boyer_moore/pattern_not_found" {
   inspect!(rabin_karp("hello world", "moon"), content="-1")
   inspect!(rabin_karp("AABAACAADAABAAABAA", "ZZZ"), content="-1")
+}
+
+///
+test "rabin_karp/empty" {
+  inspect!(rabin_karp("", ""), content="-1")
+  inspect!(rabin_karp("hello world", ""), content="-1")
+  inspect!(rabin_karp("", "world"), content="-1")
 }


### PR DESCRIPTION
### 简介

该 PR 修复了 kmp、Boyer-Moore 和 rabin-karp 三种字符串搜索算法中存在的边界处理缺陷(还顺带修复了因为版本问题带来的警告，防止未来起冲突成为报错）。

### 修复内容

当 pattern 为空时返回 -1，避免越界
当 text 为空时返回 -1
当 pattern 长于 text 时返回 -1

将rain_karp算法第23行的表达式计算中不同变量之间的隐式转换变成显式

这些情况之前未做判断，会在运行时引发数组越界异常。

### 变更说明

在三个算法函数中添加了统一的边界检查逻辑
保持行为一致性，返回 -1 表示未匹配
对应测试文件中增加了边界测试用例（已通过）
已无任何报错

### 测试情况

使用 `moon test --target js` 进行测试，所有用例通过 